### PR TITLE
Added backwards compatiblity for RabbitMQ <= 3.4 to fix for password ver...

### DIFF
--- a/lib/puppet/provider/rabbitmq_user/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmq_user/rabbitmqctl.rb
@@ -45,7 +45,11 @@ Puppet::Type.type(:rabbitmq_user).provide(:rabbitmqctl, :parent => Puppet::Provi
 
 
   def check_password
-    response = rabbitmqctl('eval', 'rabbit_auth_backend_internal:user_login_authentication(<<"' + resource[:name] + '">>, [{password, <<"' + resource[:password] +'">>}]).')
+    if ( Puppet::Util::Package.versioncmp(self.class.rabbitmq_version, '3.5.0') >= 0 )
+      response = rabbitmqctl('eval', 'rabbit_auth_backend_internal:user_login_authentication(<<"' + resource[:name] + '">>, [{password, <<"' + resource[:password] +'">>}]).')
+    else
+      response = rabbitmqctl('eval', 'rabbit_auth_backend_internal:check_user_login(<<"' + resource[:name] + '">>, [{password, <<"' + resource[:password] +'">>}]).')
+    end
     if response.include? 'invalid credentials'
         false
     else


### PR DESCRIPTION
While your patch works fine for 3.5.0 it will break for RabbitMQ 3.4:

```
Error: Execution of '/usr/sbin/rabbitmqctl eval rabbit_auth_backend_internal:user_login_authentication(<<"sensu">>, [{password, <<"sensu_rabbitmq_password_axoohaishuhoocesahbaifuo">>}]).' returned 2: Error: {undef,
           [{rabbit_auth_backend_internal,user_login_authentication,
                [<<"sensu">>,
[...]
```

I added a version check to fix this.